### PR TITLE
Update low-speed-through-vpn.md: improve sysctl params

### DIFF
--- a/ru/troubleshooting/low-speed-through-vpn.md
+++ b/ru/troubleshooting/low-speed-through-vpn.md
@@ -80,10 +80,10 @@ net.ipv4.tcp_keepalive_time = 1200
 net.ipv4.ip_local_port_range = 10000 65000
 net.ipv4.tcp_max_syn_backlog = 8192
 net.ipv4.tcp_max_tw_buckets = 5000
-net.ipv4.tcp_fack = 1
 net.ipv4.tcp_ecn = 1
 net.ipv4.tcp_sack = 1
-net.ipv4.tcp_timestamps = 1
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
 EOF
 sysctl -p
 ```

--- a/troubleshooting/low-speed-through-vpn.md
+++ b/troubleshooting/low-speed-through-vpn.md
@@ -80,10 +80,10 @@ net.ipv4.tcp_keepalive_time = 1200
 net.ipv4.tcp_local_port_range = 10000 65000
 net.ipv4.tcp_max_syn_backlog = 8192
 net.ipv4.tcp_max_tw_buckets = 5000
-net.ipv4.tcp_fack = 1
 net.ipv4.tcp_ecn = 1
 net.ipv4.tcp_sack = 1
-net.ipv4.tcp_timestamps = 1
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
 EOF
 sysctl -p
 ```


### PR DESCRIPTION
Removed 2 obviously not needed parameters (didn't touch params, that may be somewhere useful), added 2 from Hysteria 2 project docs

net.ipv4.tcp_fack - deprecated in linux 4.15(a long time ago), replaced with tcp_recovery, which enabled by default
net.ipv4.tcp_timestamps - enabled by default everywhere

https://v2.hysteria.network/docs/advanced/Performance/
Increase buffer sizes:
net.core.rmem_max = 16777216
net.core.wmem_max = 16777216